### PR TITLE
PAY-7740: Updating to select the last fee where applicable

### DIFF
--- a/acceptance-tests/test/end-to-end/pages/fee_details.js
+++ b/acceptance-tests/test/end-to-end/pages/fee_details.js
@@ -5,7 +5,8 @@ function verifyFeeDetails(feeTypeFlag, feeCode, siRefID, consolidatedOriginalFee
                           lastAmendingSI, jurisdiction1, jurisdiction2, feeType, amountType, amount, percentage, validFrom, validTo, version, reasonForFeeUpdate, naturalAccountCode,
                           memo, direction, applicantType, keyword, channel, status, editor, approver) {
   const I = this;
-  I.click(feeCode);
+  I.click(locate('a').withText(feeCode).last());
+  //I.click(feeCode);
   I.waitForText('Fee details', CCFRAcceptanceTestConstants.tenSecondWaitTime);
   I.see('Code');
   I.see(feeCode);


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/PAY-7740


### Change description
Updating to select the last fee (link) during the Functional Test - used when comparing discontinued fees as a recent change was done to bring back the most recent fee version. So the discontinued fee being displayed first was now the most recent fee instead of the oldest fee which the code compared against.

### Testing done
Change is related to Functional Tests - FT passing is all that's required.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
