### PR TITLE
PAY-8104 updated helmet version to ^3.22.0 same as pay-bubble but also amended xssFilter:false

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "govuk-frontend": "^4.3.0",
     "govuk_template_jinja": "0.25.0",
     "gulp": "4.0.2",
-    "helmet": "^3.1.0",
+    "helmet": "^3.22.0",
     "http-status-codes": "^1.1.6",
     "i18next": "^12.0.0",
     "i18next-express-middleware": "^1.7.0",
@@ -148,7 +148,8 @@
   },
   "nyc": {
     "extension": [
-      ".ts", ".js"
+      ".ts",
+      ".js"
     ],
     "include": [
       "src/main"

--- a/src/main/modules/helmet/index.ts
+++ b/src/main/modules/helmet/index.ts
@@ -19,7 +19,7 @@ export class Helmet {
   }
 
   enableFor (app: express.Express) {
-    app.use(helmet())
+    app.use(helmet({xssFilter: false}))
 
     new ContentSecurityPolicy(this.developmentMode).enableFor(app)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2316,7 +2316,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bowser@npm:^2.7.0":
+"bowser@npm:2.9.0":
   version: 2.9.0
   resolution: "bowser@npm:2.9.0"
   checksum: ffb068f11e2e49563e6bc3a0439ca8dc2df08dc260c94123dfcb8696cecf0a2263141f8d4ebf544063366bc61ad35d937c27f7ea8a9beb6e7c8ccfe0dd2fc281
@@ -3972,13 +3972,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dns-prefetch-control@npm:0.2.0":
-  version: 0.2.0
-  resolution: "dns-prefetch-control@npm:0.2.0"
-  checksum: 2d0fa4a438dc822bef9ae12f1553eec7ec5a930090ddcc72b0cd34569d0e6b5d66329576fd98a0f3669978c9d33b20b38d69cf5f510d5ec4bbb660c80ae494a0
-  languageName: node
-  linkType: hard
-
 "doctrine@npm:0.7.2":
   version: 0.7.2
   resolution: "doctrine@npm:0.7.2"
@@ -4638,13 +4631,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect-ct@npm:0.2.0":
-  version: 0.2.0
-  resolution: "expect-ct@npm:0.2.0"
-  checksum: a2887b68003512b828373a883b8146e5f19223fcdc478f6e1cbb754516e771775e300b4c34ddb6130db2bbff27dd50809312d93c2c2492f3dd6f099034bd03b9
-  languageName: node
-  linkType: hard
-
 "express@npm:4.21.2":
   version: 4.21.2
   resolution: "express@npm:4.21.2"
@@ -4927,7 +4913,7 @@ __metadata:
     gulp-plumber: ^1.2.0
     gulp-replace: ^1.0.0
     gulp-sass: ^5.1.0
-    helmet: ^3.1.0
+    helmet: ^3.22.0
     http-status-codes: ^1.1.6
     husky: ^2.0.0
     i18next: ^12.0.0
@@ -5254,13 +5240,6 @@ __metadata:
   version: 0.2.0
   resolution: "forwarded@npm:0.2.0"
   checksum: fd27e2394d8887ebd16a66ffc889dc983fbbd797d5d3f01087c020283c0f019a7d05ee85669383d8e0d216b116d720fc0cef2f6e9b7eb9f4c90c6e0bc7fd28e6
-  languageName: node
-  linkType: hard
-
-"frameguard@npm:3.1.0":
-  version: 3.1.0
-  resolution: "frameguard@npm:3.1.0"
-  checksum: bf20ef6be42a8488dd1bcde155a47a3cc0e6c52b80d6f764ef65be32ca1c69cb0fad0ff403eed336b60d1bb622f99a49e961ab80c3828483e296ee1f4e6389e8
   languageName: node
   linkType: hard
 
@@ -6135,38 +6114,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"helmet-csp@npm:2.9.4":
-  version: 2.9.4
-  resolution: "helmet-csp@npm:2.9.4"
+"helmet-csp@npm:2.10.0":
+  version: 2.10.0
+  resolution: "helmet-csp@npm:2.10.0"
   dependencies:
-    bowser: ^2.7.0
+    bowser: 2.9.0
     camelize: 1.0.0
     content-security-policy-builder: 2.1.0
     dasherize: 2.0.0
-  checksum: 9254a1934ff90703e7881609247d7a4fd369df1b37e935e623b903f349d625999ad9cbe2686b1caf9ae6003556bfacb8c1a8f5df9f7d2b50fa033e6c98a2b883
+  checksum: 27a7a78df38bdcfd02fc586e8afc6842671c8c66879bd8e73da25646e13120f9739825cce3a0988c32af7abc0cee952fc901c094c186cbcd48ab778619dff6ef
   languageName: node
   linkType: hard
 
-"helmet@npm:^3.1.0":
-  version: 3.21.2
-  resolution: "helmet@npm:3.21.2"
+"helmet@npm:^3.22.0":
+  version: 3.23.3
+  resolution: "helmet@npm:3.23.3"
   dependencies:
     depd: 2.0.0
-    dns-prefetch-control: 0.2.0
     dont-sniff-mimetype: 1.1.0
-    expect-ct: 0.2.0
     feature-policy: 0.3.0
-    frameguard: 3.1.0
     helmet-crossdomain: 0.4.0
-    helmet-csp: 2.9.4
+    helmet-csp: 2.10.0
     hide-powered-by: 1.1.0
     hpkp: 2.0.0
     hsts: 2.2.0
-    ienoopen: 1.1.0
     nocache: 2.1.0
     referrer-policy: 1.2.0
     x-xss-protection: 1.3.0
-  checksum: 78096ea5487e1207e988da5cea044fd7ec0b6493b4c1f282e52ccbc93b6e4ec352c81e8a3b69c0397e39e7c7dd9d5ffb1323ba1ec563c31d360d2095d96ee9d2
+  checksum: 7883e0e13e1c8170057b92f73544df1a9ad2152357c87fd829c6ecc25e5bdfffc3f67240d8bdcbacd571defa6d0f4e331f8c23359f5344ff464d0dfe66ff4b6e
   languageName: node
   linkType: hard
 
@@ -6473,13 +6448,6 @@ __metadata:
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e
-  languageName: node
-  linkType: hard
-
-"ienoopen@npm:1.1.0":
-  version: 1.1.0
-  resolution: "ienoopen@npm:1.1.0"
-  checksum: ed444d4d3df982502c24776a6f4916d3d38c2fc57e692fc88700f7ef13f75b97b36ca6e0ab133fd68c7c137c4a0397d40c897f3d8adbc5ff08538aedd02b626a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Jira link

See https://tools.hmcts.net/jira/browse/PAY-8104

### Change description

Due to fortify scan failing the helmet version needed updating but can't be over version4, this  has been set the same as pay-bubble and the xssfilter has been set to false.

### Testing done

Build and run application locally
### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
